### PR TITLE
Fix User EFQ bug

### DIFF
--- a/entity_decorator.module
+++ b/entity_decorator.module
@@ -56,13 +56,9 @@ abstract class EntityDecorator {
    */
   static public function find($id) {
     $class = get_called_class();
+    $info = entity_get_info($class::$entityType);
 
-    if ($class::$entityType == 'node') {
-      $entity = $class::findBy('nid', array($id))->execute();
-    }
-    else {
-      $entity = $class::findBy('id', array($id))->execute();
-    }
+    $entity = $class::findBy($info['entity keys']['id'], array($id))->execute();
 
     if (count($entity)) {
       return current($entity);

--- a/entity_decorator_finder.class.inc
+++ b/entity_decorator_finder.class.inc
@@ -18,8 +18,13 @@ class EntityDecoratorFinder {
     $this->entityType = $entityType;
     $this->class = $class;
     $this->query = new EntityFieldQuery();
-    $this->query->entityCondition('entity_type', $entityType)
-         ->entityCondition('bundle', $bundle);
+    $this->query->entityCondition('entity_type', $entityType);
+
+    // User is a "special case" as it has no bundle to query against.
+    // Setting a bundle triggers EFQ to add "WHERE 1=0" to the SQL.
+    if ($entity_type != 'user') {
+      $this->query->entityCondition('bundle', $bundle);
+    }
   }
 
 

--- a/entity_decorator_finder.class.inc
+++ b/entity_decorator_finder.class.inc
@@ -22,7 +22,7 @@ class EntityDecoratorFinder {
 
     // User is a "special case" as it has no bundle to query against.
     // Setting a bundle triggers EFQ to add "WHERE 1=0" to the SQL.
-    if ($entity_type != 'user') {
+    if ($entityType != 'user') {
       $this->query->entityCondition('bundle', $bundle);
     }
   }


### PR DESCRIPTION
If, when querying users, a bundle is set to "user", then the EFQ breaks as it triggers Drupal to add "WHERE 1=0" to the SQL as the User Entity Type does not have a bundle key.
