### PR TITLE
Added a check for the fields primary storage column as it's not always 'value'

### DIFF
--- a/entity_decorator.module
+++ b/entity_decorator.module
@@ -12,6 +12,8 @@ class EntityDecoratorMethodNotFound extends EntityDecoratorException {}
 
 class EntityDecoratorUnsupportedArgument extends EntityDecoratorException {}
 
+class EntityDecoratorFieldNotFound extends EntityDecoratorException {}
+
 abstract class EntityDecorator {
   static $entityType;
   static $bundle;

--- a/entity_decorator_finder.class.inc
+++ b/entity_decorator_finder.class.inc
@@ -81,7 +81,7 @@ class EntityDecoratorFinder {
       $this->query->propertyOrderBy($field_name, $asc_or_desc);
     }
     else {
-      $this->query->fieldOrderBy($field_name, 'value', $asc_or_desc);
+      $this->query->fieldOrderBy($field_name, $this->getColumnForField($field_name), $asc_or_desc);
     }
 
     return $this;


### PR DESCRIPTION
The findBy method assumed a field 'value' for storage. This change gets the primary column for the field and checks that instead.
